### PR TITLE
Add MQT-TZ Tests

### DIFF
--- a/analysis/mqttz/tests/cases/cryptographic.maude
+++ b/analysis/mqttz/tests/cases/cryptographic.maude
@@ -1,0 +1,132 @@
+mod CRYPTOGRAPHIC-CASES is
+  pr TEE-BEHAVIOR .
+  pr TEE-IMP-BEHAVIOR .
+  pr MQTTZ-PROGRAM-DECL .
+  pr MQTTZ-DATA .
+  pr MQTTZ-CONSTANTS .
+  pr TRANSIENT-CASES .
+
+  ops testCryptoGeneric testCryptoCipher : -> Program [ctor] .
+
+--- For Decryption
+  op constructDecryptCipherSess : -> Stmt [ctor] .
+  eq constructDecryptCipherSess = 
+    struct AesCipher sess ;
+    sess . algo := # TEE-ALG-AES-CBC-NOPAD ;
+    sess . mode := # TEE-MODE-DECRYPT ;
+    sess . keySize := # TA-AES-KEY-SIZE ;
+    sess . opHandle := # TEE-HANDLE-NULL ;
+    sess . keyHandle := # TEE-HANDLE-NULL .
+
+  op allocatedOperationForDecryptionExists : -> Stmt [ctor] .
+  eq allocatedOperationForDecryptionExists = 
+    constructDecryptCipherSess ; 
+    AllocateOperation(sess . algo, sess . mode, sess . keySize ; res, sess . opHandle) .
+
+  op keySetOperationForDecryptionExists : -> Stmt [ctor] .
+  eq keySetOperationForDecryptionExists = 
+    allocatedOperationForDecryptionExists ;
+    populatedTransientObjExists ;
+    SetOperationKey(sess . opHandle, sess . keyHandle  ; res) ;
+    FreeTransientObject(sess . keyHandle ;  sess . keyHandle) . --- to see result easier, assume FreeTransient is already tested
+
+--- For Encryption
+  op keySetOperationForEncryptionExists : -> Stmt [ctor] .
+  eq keySetOperationForEncryptionExists = 
+    allocatedOperationForEncryptionExists ;
+    populatedTransientObjExists ;
+    SetOperationKey(sess . opHandle, sess . keyHandle  ; res) ;
+    FreeTransientObject(sess . keyHandle ;  sess . keyHandle) . --- to see result easier, assume FreeTransient is already tested
+
+  op constructEncryptCipherSess : -> Stmt [ctor] .
+  eq constructEncryptCipherSess = 
+    struct AesCipher sess ;
+    sess . algo := # TEE-ALG-AES-CBC-NOPAD ;
+    sess . mode := # TEE-MODE-ENCRYPT ;
+    sess . keySize := # TA-AES-KEY-SIZE ;
+    sess . opHandle := # TEE-HANDLE-NULL ;
+    sess . keyHandle := # TEE-HANDLE-NULL .
+
+  op allocatedOperationForEncryptionExists : -> Stmt [ctor] .
+  eq allocatedOperationForEncryptionExists = 
+    constructEncryptCipherSess ; 
+    AllocateOperation(sess . algo, sess . mode, sess . keySize ; res, sess . opHandle) .
+
+--- Test Cases
+  eq testCryptoGeneric = 
+    struct {
+      var algo ;
+      var mode ;
+      var keySize ;
+      var opHandle ;
+      var keyHandle 
+    } AesCipher ;
+
+    main () {
+      var attr ; var res ;
+      var iv ; iv := # noData ;
+
+      --- Location: alloc_resources
+      --- Test Case 1 (For TEE_AllocateOperation)
+      --- constructEncryptCipherSess ;
+      --- AllocateOperation(sess . algo, sess . mode, sess . keySize ; res, sess . opHandle) ;
+      --- return sess . opHandle
+
+      --- Test Case 2 (For TEE_SetOperationKey)
+      --- allocatedOperationForEncryptionExists ;
+      --- populatedTransientObjExists ;
+      --- SetOperationKey(sess . opHandle, sess . keyHandle  ; res) ;
+      --- return res
+
+      --- Test Case 3 (For TEE_FreeOperation)
+      --- allocatedOperationForEncryptionExists ;
+      --- FreeOperation(sess . opHandle ;  sess . opHandle) ;
+      --- return res
+
+      --- Location: set_aes_key
+      --- Test Case 4 (For TEE_ResetOperation)
+      keySetOperationForEncryptionExists ;
+      CipherInit(sess . opHandle, iv ;) ; --- Tested below
+      ResetOperation(sess . opHandle ;) ;
+      return res
+    }
+  .
+  
+  eq testCryptoCipher = 
+    struct {
+      var algo ;
+      var mode ;
+      var keySize ;
+      var opHandle ;
+      var keyHandle 
+    } AesCipher ;
+
+    main () {
+      var attr ; var res ;
+      var iv ; iv := # noData ;
+      var encData ; var decData ;
+
+      --- Location: set_aes_iv
+      --- Test Case 1 (For TEE_CipherInit)
+      --- keySetOperationForEncryptionExists ;
+      --- CipherInit(sess . opHandle, iv ;) ;
+      --- return res
+
+      --- Location: cipher_buffer
+      --- Test Case 2 (For TEE_CipherUpdate, decryption)
+      --- encData := # encrypted(data(7), TEE-ALG-AES-CBC-NOPAD, key(teeAttribute(TEE-ATTR-SECRET-VALUE, randomAttrVal))) ;
+      --- decData := # noData ;
+      --- keySetOperationForDecryptionExists ;
+      --- CipherInit(sess . opHandle, iv ;) ;
+      --- CipherUpdate(sess . opHandle , encData ; res, decData) ;
+      --- return decData
+
+      --- Test Case 3 (For TEE_CipherUpdate, encryption)
+      encData := # data(7) ; decData := # noData ;
+      keySetOperationForEncryptionExists ;
+      CipherInit(sess . opHandle, iv ;) ;
+      CipherUpdate(sess . opHandle , encData ; res, decData) ;
+      return decData
+    }
+  .
+endm

--- a/analysis/mqttz/tests/cases/data-stream.maude
+++ b/analysis/mqttz/tests/cases/data-stream.maude
@@ -1,0 +1,34 @@
+mod DATA-STREAM-CASES is
+  pr TEE-BEHAVIOR .
+  pr TEE-IMP-BEHAVIOR .
+  pr MQTTZ-PROGRAM-DECL .
+  pr MQTTZ-DATA .
+  pr MQTTZ-CONSTANTS .
+  pr MQTTZ-RA-BEHAVIOR .
+
+  op testDataStream : -> Program [ctor] .
+
+  op openedHandleToPersistentObj : -> Stmt [ctor] .
+  eq openedHandleToPersistentObj = 
+      OpenPersistentObject(# TEE-STORAGE-PRIVATE, # fileName(pub(1)), 
+                           # (TEE-DATA-FLAG-ACCESS-READ, TEE-DATA-FLAG-SHARE-READ,
+                              TEE-DATA-FLAG-ACCESS-WRITE, TEE-DATA-FLAG-SHARE-WRITE) ; res, object) .
+
+  eq testDataStream = 
+    main () {
+      var res ; var object ;
+      var data ;
+
+      --- Location: read_raw_object
+      --- Test Case 1 (For TEE_ReadObjectData)
+      --- openedHandleToPersistentObj ;
+      --- ReadObjectData(object, # dataSize(1)  ; res, data) ;
+      --- return data
+
+      --- Test Case 2 (TEE_WriteObjectData)
+      openedHandleToPersistentObj ;
+      WriteObjectData(object, # attrContentData(keyAttrValue(pub(2)))  ; res ) ;
+      return res
+    }
+  .
+endm

--- a/analysis/mqttz/tests/cases/generic.maude
+++ b/analysis/mqttz/tests/cases/generic.maude
@@ -1,0 +1,28 @@
+mod GENERIC-CASES is
+  pr TEE-BEHAVIOR .
+  pr TEE-IMP-BEHAVIOR .
+  pr MQTTZ-PROGRAM-DECL .
+  pr PERSISTENT-CASES .
+  pr DATA-STREAM-CASES .
+
+  op testGeneric : -> Program [ctor] .
+
+  eq testGeneric = 
+    main () {
+      var res ; var object ;
+      var objDataFlag ;
+
+      --- Location: read_raw_object
+      --- Test Case 1 (For TEE_CloseObject, closing an opened handle) (require a scenario with keys)
+      --- openedHandleToPersistentObj ;
+      --- CloseObject(object  ; object) ;
+      --- return res
+
+      --- Location: save_key
+      --- Test Case 2 (TEE_CloseObject, closing a newly created persistent obj's handle)
+      createdPersistentObj ;
+      CloseObject(object  ; object) ;
+      return res
+    }
+  .
+endm

--- a/analysis/mqttz/tests/cases/persistent.maude
+++ b/analysis/mqttz/tests/cases/persistent.maude
@@ -1,0 +1,45 @@
+mod PERSISTENT-CASES is
+  pr TEE-BEHAVIOR .
+  pr TEE-IMP-BEHAVIOR .
+  pr MQTTZ-PROGRAM-DECL .
+  pr MQTTZ-DATA .
+  pr MQTTZ-CONSTANTS .
+  pr MQTTZ-RA-BEHAVIOR .
+
+  op testPersistent : -> Program [ctor] .
+
+  op createdPersistentObj : -> Stmt [ctor] .
+  eq createdPersistentObj = 
+      objDataFlag := # (TEE-DATA-FLAG-ACCESS-READ, TEE-DATA-FLAG-ACCESS-WRITE, 
+                        TEE-DATA-FLAG-ACCESS-WRITE-META, TEE-DATA-FLAG-OVERWRITE) ;
+      object  := # handleId(0, ta) ; 
+      CreatePersistentObject(# TEE-STORAGE-PRIVATE, # fileName(pub(2)), objDataFlag, 
+                             # TEE-HANDLE-NULL, # noData, # dataSize(0), object  ; res , object) .
+
+  eq testPersistent = 
+    main () {
+      var res ; var object ;
+      var objDataFlag ;
+
+      --- Location: save_key
+      --- Test Case 1 (For TEE_CreatePersistentObject, creating a new persistent obj)
+      --- objDataFlag := # (TEE-DATA-FLAG-ACCESS-READ, TEE-DATA-FLAG-ACCESS-WRITE, 
+      ---                   TEE-DATA-FLAG-ACCESS-WRITE-META, TEE-DATA-FLAG-OVERWRITE) ;
+      --- object  := # handleId(0, ta) ; 
+      --- CreatePersistentObject(# TEE-STORAGE-PRIVATE, # fileName(pub(2)), objDataFlag, 
+      ---                        # TEE-HANDLE-NULL, # noData, # dataSize(0), object  ; res , object) ;
+      --- return res
+
+      --- Test Case 2 (For TEE_CloseAndDeletePersistentObject1)
+      --- createdPersistentObj ;
+      --- CloseAndDeletePersistentObject1(object ; res, object) ;
+      --- return res
+
+      --- Location : read_raw_object
+      --- Test Case 3 (For TEE_OpenPersistentObject) (require scenario with keys)
+      OpenPersistentObject(# TEE-STORAGE-PRIVATE, # fileName(pub(1)), 
+                           # (TEE-DATA-FLAG-ACCESS-READ, TEE-DATA-FLAG-SHARE-READ) ; res, object) ;
+      return object
+    }
+  .
+endm

--- a/analysis/mqttz/tests/cases/transient.maude
+++ b/analysis/mqttz/tests/cases/transient.maude
@@ -1,0 +1,28 @@
+mod TRANSIENT-CASES is
+  pr TEE-BEHAVIOR .
+  pr TEE-IMP-BEHAVIOR .
+  pr MQTTZ-PROGRAM-DECL .
+  pr MQTTZ-DATA .
+
+  op testTransient : -> Program [ctor] .
+
+  eq testTransient = 
+    struct {
+      var algo ;
+      var mode ;
+      var keySize ;
+      var opHandle ;
+      var keyHandle 
+    } AesCipher ;
+
+    main () {
+      struct AesCipher sess ;
+      var res ;
+
+      --- Location: alloc_resources
+      --- Test Case 1
+      AllocateTransientObject(# TEE-TYPE-AES, # TA-AES-KEY-SIZE  ; res, sess . keyHandle) ;
+      return res
+    }
+  .
+endm

--- a/analysis/mqttz/tests/cases/transient.maude
+++ b/analysis/mqttz/tests/cases/transient.maude
@@ -6,6 +6,19 @@ mod TRANSIENT-CASES is
 
   op testTransient : -> Program [ctor] .
 
+  op varDecls : -> Stmt [ctor] .
+  eq varDecls = 
+      struct AesCipher sess ;
+      var res ; var attr
+  .
+
+
+  op populatedTransientObjExists : -> Stmt [ctor] .
+  eq populatedTransientObjExists = 
+    AllocateTransientObject(# TEE-TYPE-AES, # TA-AES-KEY-SIZE  ; res, sess . keyHandle) ;
+    InitRefAttribute(# TEE-ATTR-SECRET-VALUE, # randomAttrVal  ; attr) ;
+    PopulateTransientObject(sess . keyHandle, attr  ; res) .
+
   eq testTransient = 
     struct {
       var algo ;
@@ -16,12 +29,38 @@ mod TRANSIENT-CASES is
     } AesCipher ;
 
     main () {
-      struct AesCipher sess ;
-      var res ;
+      varDecls ;
 
       --- Location: alloc_resources
-      --- Test Case 1
-      AllocateTransientObject(# TEE-TYPE-AES, # TA-AES-KEY-SIZE  ; res, sess . keyHandle) ;
+      --- Test Case 1 (For TEE_AllocateTransientObject)
+      --- AllocateTransientObject(# TEE-TYPE-AES, # TA-AES-KEY-SIZE  ; res, sess . keyHandle) ;
+      --- return res
+
+      --- Test Case 2 (For TEE_InitRefAttribute)
+      --- InitRefAttribute(# TEE-ATTR-SECRET-VALUE, # randomAttrVal  ; attr) ;
+      --- return attr
+
+      --- Test Case 3 (For TEE_PopulateTransientObject)
+      --- AllocateTransientObject(# TEE-TYPE-AES, # TA-AES-KEY-SIZE  ; res, sess . keyHandle) ;
+      --- InitRefAttribute(# TEE-ATTR-SECRET-VALUE, # randomAttrVal  ; attr) ;
+      --- PopulateTransientObject(sess . keyHandle, attr  ; res) ;
+      --- return res
+
+      --- Test Case 4 (For TEE_FreeTransientObject)
+      --- populatedTransientObjExists ;
+      --- FreeTransientObject(sess . keyHandle ;  sess . keyHandle) ;
+      --- return res
+
+      --- Location: set_aes_key
+      --- Test Case 5 (For TEE_ResetTransientObject)
+      --- populatedTransientObjExists ;
+      --- ResetTransientObject(sess . keyHandle  ;   ) ; 
+      --- return res
+
+      --- Test Case 6 (For TEE_PopulateTransientObject after TEE_ResetTransientObject)
+      populatedTransientObjExists ;
+      ResetTransientObject(sess . keyHandle  ;   ) ; 
+      PopulateTransientObject(sess . keyHandle, attr  ; res) ;
       return res
     }
   .

--- a/analysis/mqttz/tests/main.maude
+++ b/analysis/mqttz/tests/main.maude
@@ -1,9 +1,11 @@
 load ../main
 load ../../scenario/aux
 load ./cases/transient
+load ./cases/persistent
 
 mod TEST-CASES is
   pr TRANSIENT-CASES .
+  pr PERSISTENT-CASES .
 endm
 
 mod TEST-SCENARIO is
@@ -16,7 +18,8 @@ mod TEST-SCENARIO is
   var APPID : AppId .
 
   op testClients : -> List{SubId} .
-  eq testClients = {pub(1)} {sub(1)} .
+  --- eq testClients = {pub(1)} {sub(1)} .
+  eq testClients = {pub(1)} .
 
   op initTestTa : Program -> Configuration .
   eq initTestTa(P) = < ta : TrustApp | proc : none , prog : P , running : false ,
@@ -37,4 +40,6 @@ mod TEST-SCENARIO is
 
 endm
 
-rew scenarioWithoutKeys(testTransient) .
+--- rew scenarioWithoutKeys(testTransient) .
+--- rew scenarioWithoutKeys(testPersistent) .
+rew scenarioWithKeys(testPersistent) .

--- a/analysis/mqttz/tests/main.maude
+++ b/analysis/mqttz/tests/main.maude
@@ -1,0 +1,40 @@
+load ../main
+load ../../scenario/aux
+load ./cases/transient
+
+mod TEST-CASES is
+  pr TRANSIENT-CASES .
+endm
+
+mod TEST-SCENARIO is
+  pr SCENARIO-AUX .
+  pr TEST-CASES .
+
+  vars P TAPROG : Program .
+  var RAID : Oid .
+  var TAINSTID : TaInstId .
+  var APPID : AppId .
+
+  op testClients : -> List{SubId} .
+  eq testClients = {pub(1)} {sub(1)} .
+
+  op initTestTa : Program -> Configuration .
+  eq initTestTa(P) = < ta : TrustApp | proc : none , prog : P , running : false ,
+                                       app-status : normal , api-call : noCall , api-return : noReturn ,
+                                       current-api : noApi , api-state : noState , current-params : empty , id-counter : 0 ,
+                                       trust-app-id : REENCRYPT ,
+                                       task : task({sessionId(0) , main , nil} , ra) , task-counter : 0, state-changed : false > .
+
+  --- Testing transient & cryptographic operations API
+  op scenarioWithoutKeys : Program -> Configuration .
+  eq scenarioWithoutKeys(P) 
+   = initTestTa(P) initTrustedOS(testClients) .
+
+  --- Testing persistent & data stream API
+  op scenarioWithKeys : Program -> Configuration .
+  eq scenarioWithKeys(P) 
+   = initTestTa(P) initTrustedOS(testClients) shareKeys(testClients) .
+
+endm
+
+rew scenarioWithoutKeys(testTransient) .

--- a/analysis/mqttz/tests/main.maude
+++ b/analysis/mqttz/tests/main.maude
@@ -2,10 +2,14 @@ load ../main
 load ../../scenario/aux
 load ./cases/transient
 load ./cases/persistent
+load ./cases/data-stream
+load ./cases/generic
 
 mod TEST-CASES is
   pr TRANSIENT-CASES .
   pr PERSISTENT-CASES .
+  pr DATA-STREAM-CASES .
+  pr GENERIC-CASES .
 endm
 
 mod TEST-SCENARIO is
@@ -42,4 +46,7 @@ endm
 
 --- rew scenarioWithoutKeys(testTransient) .
 --- rew scenarioWithoutKeys(testPersistent) .
-rew scenarioWithKeys(testPersistent) .
+--- rew scenarioWithKeys(testPersistent) .
+--- rew scenarioWithKeys(testDataStream) .
+--- rew scenarioWithKeys(testGeneric) .
+rew scenarioWithoutKeys(testGeneric) .

--- a/analysis/mqttz/tests/main.maude
+++ b/analysis/mqttz/tests/main.maude
@@ -4,12 +4,14 @@ load ./cases/transient
 load ./cases/persistent
 load ./cases/data-stream
 load ./cases/generic
+load ./cases/cryptographic
 
 mod TEST-CASES is
   pr TRANSIENT-CASES .
   pr PERSISTENT-CASES .
   pr DATA-STREAM-CASES .
   pr GENERIC-CASES .
+  pr CRYPTOGRAPHIC-CASES .
 endm
 
 mod TEST-SCENARIO is
@@ -44,9 +46,16 @@ mod TEST-SCENARIO is
 
 endm
 
+--- Tests for Trust Storage APIs
+--- 
 --- rew scenarioWithoutKeys(testTransient) .
 --- rew scenarioWithoutKeys(testPersistent) .
 --- rew scenarioWithKeys(testPersistent) .
 --- rew scenarioWithKeys(testDataStream) .
 --- rew scenarioWithKeys(testGeneric) .
-rew scenarioWithoutKeys(testGeneric) .
+--- rew scenarioWithoutKeys(testGeneric) .
+
+--- Tests for Cryptographic Operation APIs
+--- 
+--- rew scenarioWithoutKeys(testCryptoGeneric) .
+rew scenarioWithoutKeys(testCryptoCipher) .


### PR DESCRIPTION
Added test cases for Trusted Storage and Crypto. Op. APIs used by the MQT-TZ broker TA.
The newly added tests follows the same structure as the KMGK tests.